### PR TITLE
Remove odoo_source from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ logs/odoo.log
 logs/startup.log
 .DS_Store
 .venv/
-odoo_source


### PR DESCRIPTION
## Summary
- Remove `odoo_source` from .gitignore to allow tracking

## Test plan
- [x] Verify .gitignore no longer contains odoo_source entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)